### PR TITLE
relax the redcarpet dependency versioning

### DIFF
--- a/bullet_instructure.gemspec
+++ b/bullet_instructure.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "uniform_notifier", "~> 1.9.0"
-  s.add_runtime_dependency "redcarpet", "3.0.0"
+  s.add_runtime_dependency "redcarpet", ">= 3.0.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This way projects that pull in this gem can still use a newer version of redcarpet.
